### PR TITLE
Adds auto variables and made rm failsafe

### DIFF
--- a/bash/deploy.sh
+++ b/bash/deploy.sh
@@ -10,8 +10,16 @@ CLONE=${TEMP}/clone
 echo -e "Cloning Github repository:"
 git clone "${URL}" "${CLONE}"
 
-echo -e "\nBuilding Jekyll site:"
+echo -e "\nRegistering variables:"
 cd "${CLONE}"
+USER_EMAIL=$(git config --get user.email)
+USER_EMAIL=${USER_EMAIL:-"jgd@teamed.io"}
+USER_NAME=$(git config --get user.name)
+USER_NAME=${USER_NAME:-"jekyll-github-deploy"}
+
+VERSION=$(git describe --always --tag)
+
+echo -e "\nBuilding Jekyll site:"
 rm -rf _site
 jekyll build
 cp -R _site ${TEMP}
@@ -26,11 +34,11 @@ fi
 echo -e "\nDeploying into gh-pages branch:"
 rm -rf *
 cp -R ${TEMP}/_site/* .
-rm README.md
+rm -f README.md
 git add .
-git config user.email "jgd@teamed.io"
-git config user.name "jekyll-github-deploy"
-git commit -am "new site version deployed" --allow-empty
+git config user.email "${USER_EMAIL}"
+git config user.name "${USER_NAME}"
+git commit -am "new site version ${VERSION} deployed" --allow-empty
 git push origin gh-pages 2>&1 | sed 's|'$URL'|[skipped]|g'
 
 echo -e "\nCleaning up:"


### PR DESCRIPTION
Variables are now used for username and email and auto populated with
values from original repos (using git config --get)
README.md removal doesn't fail anymore if the file doesn't exist.
If git doesn't return config values, previous defaults are used.

Debug messages now output deployed version (including tag).
