### PR TITLE
Add addtional CLI option --branch-from

### DIFF
--- a/bash/deploy.sh
+++ b/bash/deploy.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 URL=$1
 BRANCH=$2
+BRANCH_FROM=$3
 SRC=$(pwd)
 TEMP=$(mktemp -d -t jgd-XXX)
 trap "rm -rf ${TEMP}" EXIT
@@ -12,7 +13,7 @@ CLONE=${TEMP}/clone
 COPY=${TEMP}/copy
 
 echo -e "Cloning Github repository:"
-git clone "${URL}" "${CLONE}"
+git clone -b "${BRANCH_FROM}" "${URL}" "${CLONE}"
 cp -R ${CLONE} ${COPY}
 
 cd "${CLONE}"

--- a/bin/jgd
+++ b/bin/jgd
@@ -10,10 +10,13 @@ Usage: jgd [options]
   EOS
   opt :url, 'Github URL', type: String, default: ''
   opt :branch, 'Destination branch', type: String, default: 'gh-pages'
+  opt :branch_from, 'Source branch', type: String, default: 'master'
 end
 
 branch = opts[:branch]
+branch_from = opts[:branch_from]
 fail 'branch can\'t be empty' if branch.empty?
+fail 'branch-from can\'t be empty' if branch_from.empty?
 url = opts[:url]
 url = `git config --get remote.origin.url`.strip if url.empty?
 
@@ -22,4 +25,4 @@ root = spec.gem_dir
 script = File.join(root, 'bash/deploy.sh')
 
 fail 'deployment failed, see log above' \
-  unless system("#{script} #{url} #{branch}")
+  unless system("#{script} #{url} #{branch} #{branch_from}")

--- a/test.sh
+++ b/test.sh
@@ -14,7 +14,7 @@ git config user.name "Test"
 git commit -am 'initial commit'
 cd "${CWD}"
 
-./bash/deploy.sh "${TMP}" gh-pages
+./bash/deploy.sh "${TMP}" gh-pages master
 
 cd "${TMP}"
 git checkout gh-pages


### PR DESCRIPTION
This supports a little more flexibility in which
branches can be used for deploying and building.

Specifically, it lets a user build from some non-master
branch and push to a master branch, which is useful
if you're deploying to the standard myname.github.io.

Example:

jgd --branch master --branch-from source
