### PR TITLE
Support Jekyll Drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jgd
 
 Now your site is deployed to `gh-pages` branch of your repo. Done.
 
-## Comand Line Options
+## Command Line Options
 
 Below is a list of all command line options.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Below is a list of all command line options.
 | `-b` or `--branch` | The branch to push your site to. Defaults to `gh-pages`. If the branch does not exist, it will be created. |
 | `-r` or `--branch-from` | The source branch. Defaults to `master`. |
 | `-c` or `--config` | Name of the optional deploy config file. See [Production variables](#production-variables) below for more information. |
+| `-d` or `--drafts` | Adds the `--drafts` option to Jekyll so that it will build draft posts. |
 | `-h` or `--help` | Displays a list of all options. |
 
 ## Production variables

--- a/bash/deploy.sh
+++ b/bash/deploy.sh
@@ -8,6 +8,7 @@ BRANCH=$2
 BRANCH_FROM=$3
 DEPLOY_CONFIG=$4
 BUNDLE=$5
+DRAFTS=$6
 SRC=$(pwd)
 TEMP=$(mktemp -d -t jgd-XXX)
 trap "rm -rf ${TEMP}" EXIT
@@ -24,9 +25,9 @@ echo -e "\nBuilding Jekyll site:"
 rm -rf _site
 
 if [ -r ${DEPLOY_CONFIG} ]; then
-  ${BUNDLE} jekyll build --config _config.yml,${DEPLOY_CONFIG}
+  ${BUNDLE} jekyll build --config _config.yml,${DEPLOY_CONFIG} ${DRAFTS}
 else
-  ${BUNDLE} jekyll build
+  ${BUNDLE} jekyll build ${DRAFTS}
 fi
 
 if [ ! -e _site ]; then

--- a/bin/jgd
+++ b/bin/jgd
@@ -13,6 +13,7 @@ Usage: jgd [options]
   opt :branch_from, 'Source branch', type: String, default: 'master'
   opt :config, 'Deploy Config File', type: String, default: '_config-deploy.yml'
   opt :bundle, 'Use bundle'
+  opt :drafts, 'Generate drafts'
 end
 
 branch = opts[:branch]
@@ -23,11 +24,12 @@ fail 'branch-from can\'t be empty' if branch_from.empty?
 fail 'config can\'t be empty' if config.empty?
 url = opts[:url]
 url = `git config --get remote.origin.url`.strip if url.empty?
-bundle = opts[:bundle] ? '"bundle exec"' : ''
+bundle = opts[:bundle] ? '"bundle exec"' : '""'
+drafts = opts[:drafts] ? '"--drafts"' : '""'
 
 spec = Gem::Specification.find_by_name('jgd')
 root = spec.gem_dir
 script = File.join(root, 'bash/deploy.sh')
 
 fail 'deployment failed, see log above' \
-  unless system("#{script} #{url} #{branch} #{branch_from} #{config} #{bundle}")
+  unless system("#{script} #{url} #{branch} #{branch_from} #{config} #{bundle} #{drafts}")


### PR DESCRIPTION
The PR adds a `--drafts` command line option that will be passed on to the Jekyll build. I have the use case for doing a draft build for an "internal" blog, but push the non-draft build externally.

If approved, could you please merge and publish a `v1.11` as soon as possible? Thx.